### PR TITLE
v0.4.0 support if(:condition, then: [A, B, C], else: [B, C, D])

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Fixed to work with and make optional dependencies for sidekiq and railties. Confirmed as working with ruby >= 3.1.4
 
-## [0.3.1-RC1] - 2023-12-29
+## [0.4.0-RC1] - 2023-12-29
 
 - All internal restructuring/refactoring into domains. 
+- Add support for organize `self.if(:condition, then: A, else: B)` syntax

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 - Fixed to work with and make optional dependencies for sidekiq and railties. Confirmed as working with ruby >= 3.1.4
 
-## [0.4.0-RC1] - 2023-12-29
+## [0.4.0] - 2023-12-29
 
 - All internal restructuring/refactoring into domains. 
 - Add support for organize `self.if(:condition, then: A, else: B)` syntax

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,6 @@
 
 - Fixed to work with and make optional dependencies for sidekiq and railties. Confirmed as working with ruby >= 3.1.4
 
+## [0.3.1-RC1] - 2023-12-29
+
+- All internal restructuring/refactoring into domains. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,4 @@
 
 - All internal restructuring/refactoring into domains. 
 - Add support for organize `self.if(:condition, then: A, else: B)` syntax
+- change location of matchers to `require 'interactify/rspec_matchers/matchers'`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    interactify (0.3.1.pre.RC1)
+    interactify (0.4.0)
       activesupport (>= 6.0.0)
       interactor
       interactor-contracts

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    interactify (0.3.0.pre.RC1)
+    interactify (0.3.1.pre.RC1)
       activesupport (>= 6.0.0)
       interactor
       interactor-contracts

--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ end
 
 ### Using the RSpec matchers
 ```ruby
-# e.g. in spec/supoort/interactify.rb
-require 'interactify/rspec/matchers'
+# e.g. in spec/support/interactify.rb
+require 'interactify/rspec_matchers/matchers'
 
+# in specs
 expect(described_class).to expect_inputs(:foo, :bar, :baz)
 expect(described_class).to promise_outputs(:fee, :fi, :fo, :fum)
 ```

--- a/README.md
+++ b/README.md
@@ -232,6 +232,12 @@ class OuterThing
 
     # alternative hash syntax
     {if: :key_set_on_context, then: DoThingA, else: DoThingB},
+
+    # method call with hash syntax, plus implicit chaining
+    self.if(:key_set_on_context, then: [A, B, C], else: [B, C, D]),
+
+    # method call with lambda, hash syntax, and implicit chaining
+    self.if(->(ctx) { ctx.this }, then: [A, B, C], else: [B, C, D]),
     AfterDoThis
 end
 ```

--- a/gemfiles/no_railties_no_sidekiq.gemfile
+++ b/gemfiles/no_railties_no_sidekiq.gemfile
@@ -5,12 +5,14 @@ source "https://rubygems.org"
 gem "rake", "~> 13.0"
 
 group :development do
+  gem "appraisal"
   gem "bundler", "~> 2.0"
 end
 
 group :test do
-  gem "simplecov", require: false
+  gem "debug"
   gem "rspec", "~> 3.0"
+  gem "simplecov", require: false
 end
 
 gemspec path: "../"

--- a/gemfiles/no_railties_no_sidekiq.gemfile.lock
+++ b/gemfiles/no_railties_no_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    interactify (0.3.0.pre.alpha.2)
+    interactify (0.4.0)
       activesupport (>= 6.0.0)
       interactor
       interactor-contracts

--- a/gemfiles/railties_6_no_sidekiq.gemfile
+++ b/gemfiles/railties_6_no_sidekiq.gemfile
@@ -6,12 +6,14 @@ gem "rake", "~> 13.0"
 gem "railties", "6"
 
 group :development do
+  gem "appraisal"
   gem "bundler", "~> 2.0"
 end
 
 group :test do
-  gem "simplecov", require: false
+  gem "debug"
   gem "rspec", "~> 3.0"
+  gem "simplecov", require: false
 end
 
 gemspec path: "../"

--- a/gemfiles/railties_6_no_sidekiq.gemfile.lock
+++ b/gemfiles/railties_6_no_sidekiq.gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: ..
   specs:
-    interactify (0.3.0.pre.alpha.2)
+    interactify (0.4.0)
+      activesupport (>= 6.0.0)
       interactor
       interactor-contracts
 

--- a/gemfiles/railties_6_sidekiq.gemfile
+++ b/gemfiles/railties_6_sidekiq.gemfile
@@ -7,12 +7,14 @@ gem "railties", "6"
 gem "sidekiq", "7"
 
 group :development do
+  gem "appraisal"
   gem "bundler", "~> 2.0"
 end
 
 group :test do
-  gem "simplecov", require: false
+  gem "debug"
   gem "rspec", "~> 3.0"
+  gem "simplecov", require: false
 end
 
 gemspec path: "../"

--- a/gemfiles/railties_6_sidekiq.gemfile.lock
+++ b/gemfiles/railties_6_sidekiq.gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: ..
   specs:
-    interactify (0.3.0.pre.alpha.2)
+    interactify (0.4.0)
+      activesupport (>= 6.0.0)
       interactor
       interactor-contracts
 

--- a/gemfiles/railties_7_no_sidekiq.gemfile
+++ b/gemfiles/railties_7_no_sidekiq.gemfile
@@ -6,12 +6,14 @@ gem "rake", "~> 13.0"
 gem "railties", "7"
 
 group :development do
+  gem "appraisal"
   gem "bundler", "~> 2.0"
 end
 
 group :test do
-  gem "simplecov", require: false
+  gem "debug"
   gem "rspec", "~> 3.0"
+  gem "simplecov", require: false
 end
 
 gemspec path: "../"

--- a/gemfiles/railties_7_no_sidekiq.gemfile.lock
+++ b/gemfiles/railties_7_no_sidekiq.gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: ..
   specs:
-    interactify (0.3.0.pre.alpha.2)
+    interactify (0.4.0)
+      activesupport (>= 6.0.0)
       interactor
       interactor-contracts
 

--- a/gemfiles/railties_7_sidekiq.gemfile
+++ b/gemfiles/railties_7_sidekiq.gemfile
@@ -7,12 +7,14 @@ gem "railties", "7"
 gem "sidekiq", "7"
 
 group :development do
+  gem "appraisal"
   gem "bundler", "~> 2.0"
 end
 
 group :test do
-  gem "simplecov", require: false
+  gem "debug"
   gem "rspec", "~> 3.0"
+  gem "simplecov", require: false
 end
 
 gemspec path: "../"

--- a/gemfiles/railties_7_sidekiq.gemfile.lock
+++ b/gemfiles/railties_7_sidekiq.gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: ..
   specs:
-    interactify (0.3.0.pre.alpha.2)
+    interactify (0.4.0)
+      activesupport (>= 6.0.0)
       interactor
       interactor-contracts
 

--- a/lib/interactify.rb
+++ b/lib/interactify.rb
@@ -62,7 +62,7 @@ module Interactify
 
   class << self
     def validate_app(ignore: [])
-      Interactify::InteractorWiring.new(root: Interactify.configuration.root, ignore:).validate_app
+      Interactify::Wiring.new(root: Interactify.configuration.root, ignore:).validate_app
     end
 
     def reset

--- a/lib/interactify.rb
+++ b/lib/interactify.rb
@@ -45,6 +45,11 @@ module Interactify
   end
 end
 
+Interactify.instance_eval do
+  @sidekiq_missing = nil
+  @railties_missing = nil
+end
+
 begin
   require "sidekiq"
 rescue LoadError

--- a/lib/interactify/dsl.rb
+++ b/lib/interactify/dsl.rb
@@ -22,12 +22,18 @@ module Interactify
       )
     end
 
-    def if(condition, succcess_interactor, failure_interactor = nil)
+    def if(condition, success_arg, failure_arg = nil)
+      then_else = if success_arg.is_a?(Hash) && failure_arg.nil?
+                    success_arg.slice(:then, :else)
+                  else
+                    { then: success_arg, else: failure_arg }
+                  end
+
       IfInteractor.attach_klass(
         self,
         condition,
-        succcess_interactor,
-        failure_interactor
+        then_else[:then],
+        then_else[:else]
       )
     end
 

--- a/lib/interactify/dsl/each_chain.rb
+++ b/lib/interactify/dsl/each_chain.rb
@@ -26,7 +26,7 @@ module Interactify
         this = self
 
         Class.new do                                                                    # class SomeNamespace::EachPackage
-          include Interactify                                          #   include Interactify
+          include Interactify                                                           #   include Interactify
 
           expects do                                                                    #   expects do
             required(this.plural_resource_name)                                         #     required(:packages)

--- a/lib/interactify/dsl/if_interactor.rb
+++ b/lib/interactify/dsl/if_interactor.rb
@@ -1,55 +1,47 @@
 # frozen_string_literal: true
 
 require "interactify/dsl/unique_klass_name"
+require "interactify/dsl/if_klass"
 
 module Interactify
   module Dsl
     class IfInteractor
-      attr_reader :condition, :success_interactor, :failure_interactor, :evaluating_receiver
+      attr_reader :condition, :evaluating_receiver
 
       def self.attach_klass(evaluating_receiver, condition, succcess_interactor, failure_interactor)
         ifable = new(evaluating_receiver, condition, succcess_interactor, failure_interactor)
         ifable.attach_klass
       end
 
-      def initialize(evaluating_receiver, condition, succcess_interactor, failure_interactor)
+      def initialize(evaluating_receiver, condition, succcess_arg, failure_arg)
         @evaluating_receiver = evaluating_receiver
         @condition = condition
-        @success_interactor = succcess_interactor
-        @failure_interactor = failure_interactor
+        @success_arg = succcess_arg
+        @failure_arg = failure_arg
+      end
+
+      def success_interactor
+        @success_interactor ||= build_chain(@success_arg, true)
+      end
+
+      def failure_interactor
+        @failure_interactor ||= build_chain(@failure_arg, false)
       end
 
       # allows us to dynamically create an interactor chain
       # that iterates over the packages and
       # uses the passed in each_loop_klasses
-      # rubocop:disable all
       def klass
-        this = self
+        IfKlass.new(self).klass
+      end
 
-        Class.new do                                                           
-          include Interactor                                                    
-          include Interactor::Contracts                                          
-
-          expects do                                                              
-            required(this.condition) unless this.condition.is_a?(Proc)
-          end                                                                       
-
-          define_singleton_method(:source_location) do                               
-            const_source_location this.evaluating_receiver.to_s                                     #     [file, line]
-          end                                                                          
-
-          define_method(:run!) do                                                       
-            result = this.condition.is_a?(Proc) ? this.condition.call(context) : context.send(this.condition)
-            interactor = result ? this.success_interactor : this.failure_interactor
-            interactor&.respond_to?(:call!) ? interactor.call!(context) : interactor&.call(context)
-          end
-
-          define_method(:inspect) do
-            "<#{this.namespace}::#{this.if_klass_name} #{this.condition} ? #{this.success_interactor} : #{this.failure_interactor}>"
-          end
+      # so we have something to attach subclasses to during building
+      # of the outer class, before we finalize the outer If class
+      def klass_basis
+        @klass_basis ||= Class.new do
+          include Interactify
         end
       end
-      # rubocop:enable all
 
       def attach_klass
         name = if_klass_name
@@ -62,10 +54,27 @@ module Interactify
       end
 
       def if_klass_name
-        prefix = condition.is_a?(Proc) ? "Proc" : condition
-        prefix = "If#{prefix.to_s.camelize}"
+        @if_klass_name ||=
+          begin
+            prefix = condition.is_a?(Proc) ? "Proc" : condition
+            prefix = "If#{prefix.to_s.camelize}"
 
-        UniqueKlassName.for(namespace, prefix)
+            UniqueKlassName.for(namespace, prefix)
+          end
+      end
+
+      private
+
+      def build_chain(arg, truthiness)
+        return if arg.nil?
+
+        case arg
+        when Array
+          name = "If#{condition.to_s.camelize}#{truthiness ? 'IsTruthy' : 'IsFalsey'}"
+          klass_basis.chain(name, *arg)
+        else
+          arg
+        end
       end
     end
   end

--- a/lib/interactify/dsl/if_klass.rb
+++ b/lib/interactify/dsl/if_klass.rb
@@ -62,9 +62,9 @@ module Interactify
         end
       end
 
-      def attach_method(name, &)
+      def attach_method(name, &block)
         attach do |klass, _this|
-          klass.define_method(name, &)
+          klass.define_method(name, &block)
         end
       end
 

--- a/lib/interactify/dsl/if_klass.rb
+++ b/lib/interactify/dsl/if_klass.rb
@@ -62,11 +62,13 @@ module Interactify
         end
       end
 
+      # rubocop: disable Naming/BlockForwarding
       def attach_method(name, &block)
         attach do |klass, _this|
           klass.define_method(name, &block)
         end
       end
+      # rubocop: enable Naming/BlockForwarding
 
       def attach
         this = if_builder

--- a/lib/interactify/dsl/if_klass.rb
+++ b/lib/interactify/dsl/if_klass.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Interactify
+  module Dsl
+    class IfKlass
+      attr_reader :if_builder
+
+      def initialize(if_builder)
+        @if_builder = if_builder
+      end
+
+      def klass
+        attach_expectations
+        attach_source_location
+        attach_run!
+        attach_inspect
+
+        if_builder.klass_basis
+      end
+
+      def run!(context)
+        result = condition.is_a?(Proc) ? condition.call(context) : context.send(condition)
+
+        interactor = result ? success_interactor : failure_interactor
+        interactor.respond_to?(:call!) ? interactor.call!(context) : interactor&.call(context)
+      end
+
+      private
+
+      def attach_source_location
+        attach do |_klass, this|
+          define_singleton_method(:source_location) do            #   def self.source_location
+            const_source_location this.evaluating_receiver.to_s   #     [file, line]
+          end
+        end
+      end
+
+      def attach_expectations
+        attach do |klass, this|
+          klass.expects do
+            required(this.condition) unless this.condition.is_a?(Proc)
+          end
+        end
+      end
+
+      def attach_run!
+        this = self
+
+        attach_method(:run!) do
+          this.run!(context)
+        end
+      end
+
+      delegate :condition, :success_interactor, :failure_interactor, to: :if_builder
+
+      def attach_inspect
+        this = if_builder
+
+        attach_method(:inspect) do
+          name = "#{this.namespace}::#{this.if_klass_name}"
+          "<#{name} #{this.condition} ? #{this.success_interactor} : #{this.failure_interactor}>"
+        end
+      end
+
+      def attach_method(name, &)
+        attach do |klass, _this|
+          klass.define_method(name, &)
+        end
+      end
+
+      def attach
+        this = if_builder
+
+        this.klass_basis.instance_eval do
+          yield self, this
+        end
+      end
+    end
+  end
+end

--- a/lib/interactify/rspec_matchers/matchers.rb
+++ b/lib/interactify/rspec_matchers/matchers.rb
@@ -51,7 +51,7 @@ end
 
       actual_values = Array(actual.send(meth))
 
-      @contract_matcher = Interactify::RSpec::ContractMatcher.new(
+      @contract_matcher = Interactify::RSpecMatchers::ContractMatcher.new(
         actual,
         expected_values,
         actual_values,

--- a/lib/interactify/rspec_matchers/matchers.rb
+++ b/lib/interactify/rspec_matchers/matchers.rb
@@ -3,7 +3,7 @@
 require "interactify/wiring"
 
 module Interactify
-  module RSpec
+  module RSpecMatchers
     class ContractMatcher
       attr_reader :actual, :expected_values, :actual_values, :type
 

--- a/lib/interactify/version.rb
+++ b/lib/interactify/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Interactify
-  VERSION = "0.3.0-RC1"
+  VERSION = "0.3.1-RC1"
 end

--- a/lib/interactify/version.rb
+++ b/lib/interactify/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Interactify
-  VERSION = "0.3.1-RC1"
+  VERSION = "0.4.0"
 end

--- a/spec/lib/interactify/dsl_spec.rb
+++ b/spec/lib/interactify/dsl_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.describe Interactify::Dsl do
+  self::Slot = Class.new do
+    extend Interactify::Dsl
+  end
+
+  let(:slot) { self.class::Slot }
+
+  describe ".if" do
+    context "with condition, success, and failure arguments" do
+      let(:return_value) { "some return value" }
+
+      it "passes them through to the IfInteractor" do
+        allow(described_class::IfInteractor).to receive(:attach_klass).and_return(return_value)
+
+        expect(slot.if(:condition, :success, :failure)).to eq(return_value)
+
+        expect(described_class::IfInteractor).to have_received(:attach_klass).with(
+          slot,
+          :condition,
+          :success,
+          :failure
+        )
+      end
+
+      let(:on_success1) do
+        lambda { |ctx|
+          ctx.success1 = true
+        }
+      end
+      let(:on_success2) { ->(ctx) { ctx.success2 = true } }
+
+      let(:on_failure1) { ->(ctx) { ctx.success1 = false } }
+      let(:on_failure2) { ->(ctx) { ctx.success2 = false } }
+
+      context "when the success and failure arguments are arrays" do
+        it "chains the interactors" do
+          klass = slot.if(
+            :condition,
+            [on_success1, on_success2],
+            [on_failure1, on_failure2]
+          )
+
+          expect(klass.ancestors).to include Interactor
+          expect(klass.ancestors).to include Interactor::Contracts
+
+          result = klass.call!(condition: true)
+          expect(result.success1).to eq(true)
+          expect(result.success2).to eq(true)
+
+          result = klass.call!(condition: false)
+          expect(result.success1).to eq(false)
+          expect(result.success2).to eq(false)
+        end
+      end
+
+      context "when using hash then, else syntax" do
+        it "chains the interactors" do
+          klass = slot.if(
+            :condition,
+            then: [on_success1, on_success2],
+            else: [on_failure1, on_failure2]
+          )
+
+          expect(klass.ancestors).to include Interactor
+          expect(klass.ancestors).to include Interactor::Contracts
+
+          result = klass.call!(condition: true)
+          expect(result.success1).to eq(true)
+          expect(result.success2).to eq(true)
+
+          result = klass.call!(condition: false)
+          expect(result.success1).to eq(false)
+          expect(result.success2).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/interactify/rspec_matchers/matchers_spec.rb
+++ b/spec/lib/interactify/rspec_matchers/matchers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "interactify/rspec/matchers"
+require "interactify/rspec_matchers/matchers"
 
 RSpec.describe "rspec matchers" do
   describe "expect_inputs" do

--- a/spec/lib/interactify_spec.rb
+++ b/spec/lib/interactify_spec.rb
@@ -5,6 +5,41 @@ RSpec.describe Interactify do
     expect(Interactify::VERSION).not_to be nil
   end
 
+  describe ".validate_app" do
+    before do
+      wiring = instance_double(Interactify::Wiring, validate_app: "ok")
+
+      expect(Interactify::Wiring)
+        .to receive(:new)
+        .with(root: Interactify.configuration.root, ignore:)
+        .and_return(wiring)
+    end
+
+    context "with an ignore" do
+      let(:ignore) { %w[foo bar] }
+
+      it "validates the app" do
+        expect(Interactify.validate_app(ignore:)).to eq("ok")
+      end
+    end
+
+    context "with nil ignore" do
+      let(:ignore) { nil }
+
+      it "validates the app" do
+        expect(Interactify.validate_app(ignore:)).to eq("ok")
+      end
+    end
+
+    context "with empty ignore" do
+      let(:ignore) { [] }
+
+      it "validates the app" do
+        expect(Interactify.validate_app(ignore:)).to eq("ok")
+      end
+    end
+  end
+
   describe ".reset" do
     context "with a before raise hook" do
       before do

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -9,7 +9,7 @@ SimpleCov.start do
   end
 
   add_group "Wiring", "lib/interactify/wiring"
-  add_group "RSpec matchers", "lib/interactify/rspec"
+  add_group "RSpec matchers", "lib/interactify/rspec_matchers"
 
   coverage_dir "coverage/#{ENV.fetch('RUBY_VERSION', nil)}-#{ENV.fetch('APPRAISAL', nil)}"
 end

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -4,8 +4,7 @@ require "simplecov"
 
 SimpleCov.start do
   add_group "Sidekiq jobs" do |src_file|
-    src_file.project_filename =~ %r{lib/interactify/job} ||
-      src_file.project_filename =~ %r{spec/lib/interactify/job}
+    src_file.project_filename =~ %r{lib/interactify/async}
   end
 
   add_group "Wiring", "lib/interactify/wiring"


### PR DESCRIPTION
Adds support for

```ruby

organize \
  self.if(:condition, then: A, else: B)
```

Also fixes broken interactor wiring spec code.