### PR TITLE
add support for Interactify method that accepts callable objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,6 @@
 
 ## [0.4.1] - 2023-12-29
 - Fix bug triggered when nesting each and if
+
+## [0.5.0] - 2024-01-01
+- Add support for `SetA = Interactify { _1.a = 'a' }`, lambda and block class creation syntax

--- a/README.md
+++ b/README.md
@@ -109,6 +109,24 @@ organize \
   Thing2
 ```
 
+Sometimes you also want a one liner but testability too.
+the `Interactify` method will take a block or a lambda and return an Interactify class.
+
+```ruby
+# passing a block
+DecorateOrder = Interactify do |context| 
+  context.order = context.order.decorate
+end
+
+# passing a lambda
+DecorateOrder = Interactify(some_lambda)
+
+# passing anything that responds to call
+# please note if you pass a class it will be instantiated first
+# so you can't pass a class with a constructor that takes arguments
+DecorateOrder = Interactify(callable_object)
+```
+
 ### Each/Iteration
 
 Sometimes we want an interactor for each item in a collection.

--- a/lib/interactify.rb
+++ b/lib/interactify.rb
@@ -10,6 +10,7 @@ require "interactify/contracts/promising"
 require "interactify/dsl"
 require "interactify/wiring"
 require "interactify/configuration"
+require "interactify/lambda_class_method"
 
 module Interactify
   def self.railties_missing?

--- a/lib/interactify/dsl/wrapper.rb
+++ b/lib/interactify/dsl/wrapper.rb
@@ -30,6 +30,12 @@ module Interactify
           wrap_chain
         when Proc
           wrap_proc
+        when Class
+          return interactor if interactor < Interactor
+
+          raise ArgumentError, "#{interactor} must respond_to .call" unless interactor.respond_to?(:call)
+
+          wrap_proc
         else
           interactor
         end

--- a/lib/interactify/lambda_class_method.rb
+++ b/lib/interactify/lambda_class_method.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "interactify/dsl/wrapper"
+
+def Interactify(method_callable = nil, &block)
+  to_wrap = method_callable || block
+
+  Interactify::Dsl::Wrapper.wrap(self, to_wrap)
+end

--- a/spec/integration/all_the_things_integration_spec.rb
+++ b/spec/integration/all_the_things_integration_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe "Interactify" do
   before do
     require_files("each/")
     require_files("if/")
-    require_files('')
+    require_files("")
   end
 
-  context 'without an optional thing' do
+  context "without an optional thing" do
     let(:result) { AllTheThings.promising(:a).call!(things:, optional_thing: false) }
 
     it "sets A and B, then lambda_set, then both_a_and_b, then first_more_thing, next_more_thing" do

--- a/spec/lib/interactify/dsl/wrapper_spec.rb
+++ b/spec/lib/interactify/dsl/wrapper_spec.rb
@@ -84,4 +84,44 @@ RSpec.describe Interactify::Dsl::Wrapper do
       expect(wrapped_proc).to respond_to(:call)
     end
   end
+
+  context "via the Interactify callable global method" do
+    context "when given a block" do
+      let(:interactified) do
+        Interactify do |context|
+          context.interactified_via_block = true
+        end
+      end
+
+      it "returns an interactor that works" do
+        expect(interactified.call!.interactified_via_block).to eq true
+      end
+    end
+
+    context "when given a lambda" do
+      let(:interactified) do
+        Interactify(lambda do |context|
+          context.interactified_via_lambda = true
+        end)
+      end
+
+      it "returns an interactor that works" do
+        expect(interactified.call!.interactified_via_lambda).to eq true
+      end
+    end
+
+    context "when given another callable object" do
+      let(:interactified) do
+        Interactify(Class.new do
+          define_singleton_method(:call) do |context|
+            context.interactified_via_callable = true
+          end
+        end)
+      end
+
+      it "returns an interactor that works" do
+        expect(interactified.call!.interactified_via_callable).to eq true
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds support for defining classes using blocks, procs, lambdas or any callable object.

```ruby
LoadOrder = Interactify do
  _1.order = Order.find(_1.order_id)
 end
 
SetFlag = Interactify { _1.flag = true }

SetAnotherThing = Interactify(-> (c) { c.another_thing = true })
```