### PR TITLE
add support for organizing contract validation/code as documentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,9 @@ AllCops:
     - 'tmp/**/*'
     - '.git/**/*'
     - 'bin/*'
+Style/OpenStructUse:
+  Exclude:
+    - 'spec/integration/*'
 Style/ClassAndModuleChildren:
   Exclude: 
     - 'spec/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,4 @@
 
 ## [0.5.0] - 2024-01-01
 - Add support for `SetA = Interactify { _1.a = 'a' }`, lambda and block class creation syntax
+- Add support for organizing `organize A.organizing(B, C, D), E, F` contract syntax

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    interactify (0.4.1)
+    interactify (0.5.0)
       activesupport (>= 6.0.0)
       interactor
       interactor-contracts

--- a/lib/interactify.rb
+++ b/lib/interactify.rb
@@ -10,7 +10,7 @@ require "interactify/contracts/promising"
 require "interactify/dsl"
 require "interactify/wiring"
 require "interactify/configuration"
-require "interactify/lambda_class_method"
+require "interactify/interactify_callable"
 
 module Interactify
   def self.railties_missing?

--- a/lib/interactify/contracts/helpers.rb
+++ b/lib/interactify/contracts/helpers.rb
@@ -4,6 +4,8 @@ require "interactify/async/jobable"
 require "interactify/contracts/call_wrapper"
 require "interactify/contracts/failure"
 require "interactify/contracts/setup"
+require "interactify/contracts/promising"
+require "interactify/contracts/organizing"
 require "interactify/dsl/organizer"
 
 module Interactify
@@ -11,6 +13,7 @@ module Interactify
     module Helpers
       extend ActiveSupport::Concern
 
+      # rubocop: disable Metrics/BlockLength
       class_methods do
         def expect(*attrs, filled: true)
           Setup.expects(context: self, attrs:, filled:)
@@ -22,6 +25,10 @@ module Interactify
 
         def promising(*args)
           Promising.validate(self, *args)
+        end
+
+        def organizing(*args)
+          Organizing.validate(self, *args)
         end
 
         def promised_keys
@@ -50,6 +57,7 @@ module Interactify
           clauses.instance_eval { @terms }.json&.rules&.keys
         end
       end
+      # rubocop: enable Metrics/BlockLength
 
       included do
         c = Class.new(Contracts::Failure)

--- a/lib/interactify/contracts/mismatching_organizer_error.rb
+++ b/lib/interactify/contracts/mismatching_organizer_error.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "interactify/contracts/failure"
+
+module Interactify
+  module Contracts
+    class MismatchingOrganizerError < Contracts::Failure
+      def initialize(interactor, organizing, organized_klasses)
+        @interactor = interactor
+        @organizing = organizing
+        @organized_klasses = organized_klasses
+
+        super formatted_message
+      end
+
+      private
+
+      attr_reader :interactor, :organizing, :organized_klasses
+
+      def formatted_message
+        <<~MESSAGE.chomp.strip
+          #{interactor} does not organize:
+          #{organizing.inspect}
+
+          Actual organized classes are:
+          #{organized_klasses.inspect}
+
+          #{missing_and_extra_message}
+        MESSAGE
+      end
+
+      def extra = organizing - organized_klasses
+      def missing = organized_klasses - organizing
+      def missing_message = missing.none? ? nil : "Missing classes are:\n#{missing.inspect}"
+      def extra_message = extra.none? ? nil : "Extra classes are:\n#{extra.inspect}"
+
+      def missing_and_extra_message = [missing_message, extra_message].compact.join("\n\n")
+    end
+  end
+end

--- a/lib/interactify/contracts/organizing.rb
+++ b/lib/interactify/contracts/organizing.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "interactify/contracts/mismatching_organizer_error"
+
+module Interactify
+  module Contracts
+    class Organizing
+      attr_reader :interactor, :organizing
+
+      def self.validate(interactor, *organizing)
+        new(interactor, *organizing).validate
+
+        interactor
+      end
+
+      def initialize(interactor, *organizing)
+        @interactor = interactor
+        @organizing = organizing
+      end
+
+      def validate
+        return if organizing == organized
+
+        raise MismatchingOrganizerError.new(interactor, organizing, organized)
+      end
+
+      delegate :organized, to: :interactor
+    end
+  end
+end

--- a/lib/interactify/interactify_callable.rb
+++ b/lib/interactify/interactify_callable.rb
@@ -2,8 +2,10 @@
 
 require "interactify/dsl/wrapper"
 
+# rubocop: disable Naming/MethodName
 def Interactify(method_callable = nil, &block)
   to_wrap = method_callable || block
 
   Interactify::Dsl::Wrapper.wrap(self, to_wrap)
 end
+# rubocop: enable Naming/MethodName

--- a/lib/interactify/version.rb
+++ b/lib/interactify/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Interactify
-  VERSION = "0.4.1"
+  VERSION = "0.5.0"
 end

--- a/spec/fixtures/integration_app/app/interactors/invalid_organizing/extra/outer_organizer.rb
+++ b/spec/fixtures/integration_app/app/interactors/invalid_organizing/extra/outer_organizer.rb
@@ -1,0 +1,26 @@
+require_relative '../../organizing/inner_organizer'
+
+module InvalidOrganizing
+  module Extra
+    class OuterOrganizer
+      include Interactify
+
+      Unexpected = Interactify do |context|
+        context.unexpected = true
+      end
+
+      organize \
+        Organizing::InnerOrganizer.organizing(
+          Unexpected,
+          Organizing::Organized1, 
+          Organizing::Organized2.organizing(
+            Organizing::DeeplyNestedInteractor,
+            Organizing::DeeplyNestedPromisingInteractor.promising(
+              :deeply_nested_promising_interactor_called
+            ),
+            Organizing::Organized2::Organized2Called,
+          )
+        )
+    end
+  end
+end

--- a/spec/fixtures/integration_app/app/interactors/invalid_organizing/missing/outer_organizer.rb
+++ b/spec/fixtures/integration_app/app/interactors/invalid_organizing/missing/outer_organizer.rb
@@ -1,0 +1,20 @@
+require_relative '../../organizing/inner_organizer'
+
+module InvalidOrganizing
+  module Missing
+    class OuterOrganizer
+      include Interactify
+
+      organize \
+        Organizing::InnerOrganizer.organizing(
+          Organizing::Organized1, 
+          Organizing::Organized2.organizing(
+            Organizing::DeeplyNestedInteractor,
+            Organizing::DeeplyNestedPromisingInteractor.promising(
+              :deeply_nested_promising_interactor_called
+            )
+          )
+        )
+    end
+  end
+end

--- a/spec/fixtures/integration_app/app/interactors/organizing/deeply_nested_interactor.rb
+++ b/spec/fixtures/integration_app/app/interactors/organizing/deeply_nested_interactor.rb
@@ -1,0 +1,9 @@
+module Organizing
+  class DeeplyNestedInteractor
+    include Interactify
+
+    def call
+      context.deeply_nested_interactor_called = true
+    end
+  end
+end

--- a/spec/fixtures/integration_app/app/interactors/organizing/deeply_nested_promising_interactor.rb
+++ b/spec/fixtures/integration_app/app/interactors/organizing/deeply_nested_promising_interactor.rb
@@ -1,0 +1,11 @@
+module Organizing
+  class DeeplyNestedPromisingInteractor
+    include Interactify
+
+    promise :deeply_nested_promising_interactor_called
+
+    def call
+      context.deeply_nested_promising_interactor_called = true
+    end
+  end
+end

--- a/spec/fixtures/integration_app/app/interactors/organizing/inner_organizer.rb
+++ b/spec/fixtures/integration_app/app/interactors/organizing/inner_organizer.rb
@@ -1,0 +1,20 @@
+require_relative 'organized1'
+require_relative 'organized2'
+require_relative 'deeply_nested_interactor'
+require_relative 'deeply_nested_promising_interactor'
+
+module Organizing
+  class InnerOrganizer
+    include Interactify
+
+    organize \
+      Organized1, 
+      Organized2.organizing(
+        DeeplyNestedInteractor,
+        DeeplyNestedPromisingInteractor.promising(
+          :deeply_nested_promising_interactor_called
+        ),
+        Organized2::Organized2Called
+      )
+  end
+end

--- a/spec/fixtures/integration_app/app/interactors/organizing/organized1.rb
+++ b/spec/fixtures/integration_app/app/interactors/organizing/organized1.rb
@@ -1,0 +1,11 @@
+module Organizing
+  class Organized1
+    include Interactify
+
+    promise :organized1_called
+
+    def call
+      context.organized1_called = true
+    end
+  end
+end

--- a/spec/fixtures/integration_app/app/interactors/organizing/organized2.rb
+++ b/spec/fixtures/integration_app/app/interactors/organizing/organized2.rb
@@ -1,0 +1,18 @@
+require_relative 'deeply_nested_interactor'
+require_relative 'deeply_nested_promising_interactor'
+
+module Organizing
+  class Organized2
+    include Interactify
+
+    organize(
+        DeeplyNestedInteractor,
+        DeeplyNestedPromisingInteractor.promising(
+          :deeply_nested_promising_interactor_called
+        ),
+        Organized2Called = Interactify do |context|
+          context.organized2_called = true
+        end
+      )
+  end
+end

--- a/spec/fixtures/integration_app/app/interactors/organizing/outer_organizer.rb
+++ b/spec/fixtures/integration_app/app/interactors/organizing/outer_organizer.rb
@@ -1,0 +1,19 @@
+require_relative 'inner_organizer'
+
+module Organizing
+  class OuterOrganizer
+    include Interactify
+
+    organize \
+      InnerOrganizer.organizing(
+        Organized1, 
+        Organized2.organizing(
+          DeeplyNestedInteractor,
+          DeeplyNestedPromisingInteractor.promising(
+            :deeply_nested_promising_interactor_called
+          ),
+          Organized2::Organized2Called
+        )
+      )
+  end
+end

--- a/spec/integration/all_the_things_integration_spec.rb
+++ b/spec/integration/all_the_things_integration_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe "Interactify" do
   end
 
   before do
-    require_files("each/")
-    require_files("if/")
-    require_files("")
+    load_interactify_fixtures("each")
+    load_interactify_fixtures("if/")
+    load "./spec/fixtures/integration_app/app/interactors/all_the_things.rb"
   end
 
   context "without an optional thing" do
@@ -48,14 +48,6 @@ RSpec.describe "Interactify" do
 
       expect(result.counter).to eq 8
       expect(result.heavily_nested_counter).to eq 256
-    end
-  end
-
-  def require_files(dir)
-    files = Dir.glob("./spec/fixtures/integration_app/app/interactors/#{dir}**/*.rb")
-
-    files.each do |file|
-      require file
     end
   end
 end

--- a/spec/integration/each_integration_spec.rb
+++ b/spec/integration/each_integration_spec.rb
@@ -8,16 +8,16 @@ RSpec.describe "Interactify.each" do
     end
   end
 
-  let(:thing_1) do
+  let(:thing1) do
     OpenStruct.new
   end
 
-  let(:thing_2) do
+  let(:thing2) do
     OpenStruct.new
   end
 
   it "runs the outer interactors" do
-    result = Each::Organizer.call!(things: [thing_1, thing_2])
+    result = Each::Organizer.call!(things: [thing1, thing2])
 
     expect(result.a).to eq("a")
     expect(result.b).to eq("b")

--- a/spec/integration/if_integration_spec.rb
+++ b/spec/integration/if_integration_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe "Interactify.if" do
     end
   end
 
-  let(:thing_1) do
+  let(:thing1) do
     OpenStruct.new
   end
 
-  let(:thing_2) do
+  let(:thing2) do
     OpenStruct.new
   end
 

--- a/spec/integration/organizing_spec.rb
+++ b/spec/integration/organizing_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe "Interactify.organizing" do
+  let(:outer_organized) { Organizing::OuterOrganizer.call! }
+
+  context "with valid fixtures" do
+    before do
+      load_interactify_fixtures("organizing")
+    end
+
+    it "goes through the whole chain" do
+      expect(outer_organized.deeply_nested_interactor_called).to eq(true)
+      expect(outer_organized.deeply_nested_promising_interactor_called).to eq(true)
+      expect(outer_organized.organized2_called).to eq(true)
+    end
+  end
+
+  context "with invalid fixtures" do
+    it "spots extra interactors" do
+      expect { load_interactify_fixtures("invalid_organizing/extra") }
+        .to raise_error do |err|
+        expect(err).to be_a Interactify::Contracts::MismatchingOrganizerError
+
+        expect(err.message.strip).to eq(<<~MESSAGE.strip)
+          Organizing::InnerOrganizer does not organize:
+          [InvalidOrganizing::Extra::OuterOrganizer::Unexpected, Organizing::Organized1, Organizing::Organized2]
+
+          Actual organized classes are:
+          [Organizing::Organized1, Organizing::Organized2]
+
+          Extra classes are:
+          [InvalidOrganizing::Extra::OuterOrganizer::Unexpected]
+        MESSAGE
+      end
+    end
+
+    it "spots missing interactors" do
+      expect { load_interactify_fixtures("invalid_organizing/missing") }
+        .to raise_error do |err|
+        expect(err).to be_a Interactify::Contracts::MismatchingOrganizerError
+
+        expect(err.message.chomp).to eq(<<~MESSAGE.chomp)
+          Organizing::Organized2 does not organize:
+          [Organizing::DeeplyNestedInteractor, Organizing::DeeplyNestedPromisingInteractor]
+
+          Actual organized classes are:
+          [Organizing::DeeplyNestedInteractor, Organizing::DeeplyNestedPromisingInteractor, Organizing::Organized2::Organized2Called]
+
+          Missing classes are:
+          [Organizing::Organized2::Organized2Called]
+        MESSAGE
+      end
+    end
+  end
+end

--- a/spec/lib/interactify.organizing_spec.rb
+++ b/spec/lib/interactify.organizing_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe "Interactify.organizing" do
+  describe ".organizing" do
+    module self::SomeNamespace
+      C = Interactify do |c|
+        c.c = "c"
+      end
+
+      D = Interactify do |c|
+        c.d = "d"
+      end
+
+      B = Class.new do
+        include Interactify
+        organize C
+
+        def call
+          context.b = "b"
+        end
+      end
+
+      A = Class.new do
+        include Interactify
+        organize B
+
+        def call
+          context.a = "a"
+        end
+      end
+
+      Multi = Class.new do
+        include Interactify
+        organize B, C, D
+
+        def call; end
+      end
+
+      WithoutOrganizing = Class.new do
+        include Interactify
+
+        organize A, B
+      end
+
+      ValidOrganizing = Class.new do
+        include Interactify
+
+        organize \
+          A.organizing(B),
+          B.organizing(C)
+      end
+
+      MultipleOrganizing = Class.new do
+        include Interactify
+
+        organize \
+          Multi.organizing(B, C, D)
+      end
+    end
+
+    def k(klass)
+      self.class::SomeNamespace.const_get(klass)
+    end
+
+    it "supports optional organizing calls" do
+      expect(k(:WithoutOrganizing).call!.a).to eq("a")
+      expect(k(:WithoutOrganizing).call!.b).to eq("b")
+    end
+
+    it "supports organizing calls" do
+      expect(k(:ValidOrganizing).call!.a).to eq("a")
+      expect(k(:ValidOrganizing).call!.b).to eq("b")
+    end
+
+    it "raises a loadtime error when a organize is not matching" do
+      this = self
+
+      expect_class_definition = expect do
+        Class.new do
+          include Interactify
+
+          organize \
+            this.k(:A).organizing(this.k(:B)),
+            this.k(:B).organizing(this.k(:D))
+        end
+      end
+
+      expect_class_definition.to raise_error(Interactify::Contracts::MismatchingOrganizerError) do |error|
+        expect(error.message).to eq <<~MESSAGE.chomp
+          #{k(:B)} does not organize:
+          [#{k(:D)}]
+
+          Actual organized classes are:
+          [#{k(:C)}]
+
+          Missing classes are:
+          [#{k(:C)}]
+
+          Extra classes are:
+          [#{k(:D)}]
+        MESSAGE
+      end
+    end
+  end
+end

--- a/spec/support/spec_support.rb
+++ b/spec/support/spec_support.rb
@@ -2,4 +2,18 @@
 
 module SpecSupport
   include Interactify
+
+  module LoadInteractifyFixtures
+    def load_interactify_fixtures(sub_directory)
+      files = Dir.glob("./spec/fixtures/integration_app/app/interactors/#{sub_directory}/**/*.rb")
+
+      files.each do |file|
+        load file
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include SpecSupport::LoadInteractifyFixtures
 end


### PR DESCRIPTION
This adds support for calling `.organizing` on an interactor class for automatic documenting and verifying expected behaviour of the interactor chain.

Easier to see with an example:

```ruby
organize \
  LoadOrder,
  MarkAsPaid,
  SendOutNotifications.organizing(
    EmailUser,
    SendPush,
    NotifySomeThirdParty, 
    SendOutNotifications::DoAnotherThing
  )

class SendOutNotifications
  organize \
    EmailUser,
    SendPush,
    NotifySomeThirdParty, 
    DoAnotherThing = Interactify do |context|
      context.do_another_thing = true
    end
end
```

This organizing method call is still equivalent to just

```
organize \
  LoadOrder,
  MarkAsPaid,
  SendOutNotifications
```

but it has the following benefits
1. it acts as documentation 
2. it verifies that these code-as-comments stay in sync
3. this all happens at load time
4. it's a nice jumping off point for when you need to get an overview of the whole chain
5. no runtime overhead as the `.organizing` method call returns the original interactor chain

This looks like code duplication, which in a way it is, as updating of the called organizer will require in update in any of the callers specifying `.organizing`.

But this is just another way to make the code self-documenting and kept up to date.

Which helps you to solve the open 7 or 8 files for heavily nested interactor chains and then forgetting what it was you were trying to do.

Note this mirrors and is tested with the `.promising` method calls.

```
organize \
  LoadOrder.promising(:order),
  MarkAsPaid.promising(:transaction),
  SendOutNotifications.organizing(
    EmailUser.promising(:email_address),
    SendPush,
    NotifySomeThirdParty, 
    DoAnotherThing = Interactify do |context|
```