### PR TITLE
propagate caller info

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,30 @@ gem 'interactify'
 ```ruby
 # in config/initializers/interactify.rb
 Interactify.configure do |config|
-  # default
-  # config.root = Rails.root / 'app'
-end
+  # defaults
+  config.root = Rails.root / 'app'
 
-Interactify.on_contract_breach do |context, attrs|
-  # maybe add context to Sentry or Honeybadger etc here
-end
+  config.on_contract_breach do |context, contract_failures|
+    # maybe add context to Sentry or Honeybadger etc here
+  end
 
-Interactify.before_raise do |exception|
-  # maybe add context to Sentry or Honeybadger etc here
+  # called when an Interactify.organizing or Interactify.promising fails to match the actual interactor
+  # definitions
+  config.on_definition_error = Kernel.method(:raise)
+
+  # config.on_definition_error do |error|
+  #   # you may want to raise an error in test but not in production
+  #   # or you may want to log the error
+  # end
+
+  config.before_raise do |exception|
+    # maybe add context to Sentry or Honeybadger etc here
+  end
 end
 ```
 
 ### Using the RSpec matchers
+
 ```ruby
 # e.g. in spec/support/interactify.rb
 require 'interactify/rspec_matchers/matchers'

--- a/lib/interactify.rb
+++ b/lib/interactify.rb
@@ -13,36 +13,40 @@ require "interactify/configuration"
 require "interactify/interactify_callable"
 
 module Interactify
-  def self.railties_missing?
-    @railties_missing
-  end
+  class << self
+    delegate :on_definition_error, :trigger_definition_error, to: :configuration
 
-  def self.railties_missing!
-    @railties_missing = true
-  end
+    def railties_missing?
+      @railties_missing
+    end
 
-  def self.railties
-    railties?
-  end
+    def railties_missing!
+      @railties_missing = true
+    end
 
-  def self.railties?
-    !railties_missing?
-  end
+    def railties
+      railties?
+    end
 
-  def self.sidekiq_missing?
-    @sidekiq_missing
-  end
+    def railties?
+      !railties_missing?
+    end
 
-  def self.sidekiq_missing!
-    @sidekiq_missing = true
-  end
+    def sidekiq_missing?
+      @sidekiq_missing
+    end
 
-  def self.sidekiq
-    sidekiq?
-  end
+    def sidekiq_missing!
+      @sidekiq_missing = true
+    end
 
-  def self.sidekiq?
-    !sidekiq_missing?
+    def sidekiq
+      sidekiq?
+    end
+
+    def sidekiq?
+      !sidekiq_missing?
+    end
   end
 end
 

--- a/lib/interactify/configuration.rb
+++ b/lib/interactify/configuration.rb
@@ -11,5 +11,13 @@ module Interactify
     def fallback
       Rails.root / "app" if Interactify.railties?
     end
+
+    def trigger_definition_error(error)
+      @on_definition_error&.call(error)
+    end
+
+    def on_definition_error(handler = nil, &block)
+      @on_definition_error = block_given? ? block : handler
+    end
   end
 end

--- a/lib/interactify/contracts/organizing.rb
+++ b/lib/interactify/contracts/organizing.rb
@@ -21,7 +21,9 @@ module Interactify
       def validate
         return if organizing == organized
 
-        raise MismatchingOrganizerError.new(interactor, organizing, organized)
+        Interactify.trigger_definition_error(
+          MismatchingOrganizerError.new(interactor, organizing, organized)
+        )
       end
 
       delegate :organized, to: :interactor

--- a/lib/interactify/dsl.rb
+++ b/lib/interactify/dsl.rb
@@ -24,7 +24,7 @@ module Interactify
         self,
         *each_loop_klasses,
         caller_info:,
-        plural_resource_name:,
+        plural_resource_name:
       )
     end
 

--- a/lib/interactify/dsl/each_chain.rb
+++ b/lib/interactify/dsl/each_chain.rb
@@ -9,7 +9,7 @@ module Interactify
 
       attr_reader :each_loop_klasses, :plural_resource_name, :evaluating_receiver, :caller_info
 
-      def self.attach_klass(evaluating_receiver, 
+      def self.attach_klass(evaluating_receiver,
                             *each_loop_klasses,
                             plural_resource_name:,
                             caller_info:)

--- a/lib/interactify/dsl/if_interactor.rb
+++ b/lib/interactify/dsl/if_interactor.rb
@@ -6,18 +6,19 @@ require "interactify/dsl/if_klass"
 module Interactify
   module Dsl
     class IfInteractor
-      attr_reader :condition, :evaluating_receiver
+      attr_reader :condition, :evaluating_receiver, :caller_info
 
-      def self.attach_klass(evaluating_receiver, condition, succcess_interactor, failure_interactor)
-        ifable = new(evaluating_receiver, condition, succcess_interactor, failure_interactor)
+      def self.attach_klass(evaluating_receiver, condition, succcess_interactor, failure_interactor, caller_info:)
+        ifable = new(evaluating_receiver, condition, succcess_interactor, failure_interactor, caller_info:)
         ifable.attach_klass
       end
 
-      def initialize(evaluating_receiver, condition, succcess_arg, failure_arg)
+      def initialize(evaluating_receiver, condition, succcess_arg, failure_arg, caller_info:)
         @evaluating_receiver = evaluating_receiver
         @condition = condition
         @success_arg = succcess_arg
         @failure_arg = failure_arg
+        @caller_info = caller_info
       end
 
       def success_interactor
@@ -71,7 +72,7 @@ module Interactify
         case arg
         when Array
           name = "If#{condition.to_s.camelize}#{truthiness ? 'IsTruthy' : 'IsFalsey'}"
-          klass_basis.chain(name, *arg)
+          klass_basis.chain(name, *arg, caller_info:)
         else
           arg
         end

--- a/spec/integration/organizing_spec.rb
+++ b/spec/integration/organizing_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe "Interactify.organizing" do
   end
 
   context "with invalid fixtures" do
+    before do
+      Interactify.on_definition_error(&Kernel.method(:raise))
+    end
+
     it "spots extra interactors" do
       expect { load_interactify_fixtures("invalid_organizing/extra") }
         .to raise_error do |err|

--- a/spec/lib/interactify.each_spec.rb
+++ b/spec/lib/interactify.each_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe Interactify do
       expect(klass.name).to match(/SpecSupport::EachThing\d+\z/)
 
       file, line = klass.source_location
-      expect(file).to match %r{spec/support/spec_support\.rb}
-      expect(line).to eq(3)
+      expect(file).to match __FILE__
+      expect(line).to be > 0
 
       result = klass.call!(things: [1, 2, 3])
       expect(result.a).to eq([1, 2, 3])

--- a/spec/lib/interactify.organizing_spec.rb
+++ b/spec/lib/interactify.organizing_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Interactify.organizing" do
       expect(k(:ValidOrganizing).call!.b).to eq("b")
     end
 
-    context 'with invalid organizing assertions' do
+    context "with invalid organizing assertions" do
       before do
         @errors = []
 

--- a/spec/lib/interactify/dsl/each_chain_spec.rb
+++ b/spec/lib/interactify/dsl/each_chain_spec.rb
@@ -2,8 +2,10 @@
 
 RSpec.describe Interactify::Dsl::EachChain do
   describe ".attach_klass" do
-    let(:chain) { Interactify::Dsl::EachChain.attach_klass(SpecSupport, [k(:A), k(:B)], plural_resource_name: :things, caller_info:) }
-    let(:caller_info) { '/some/path/to/file.rb:123' }
+    let(:chain) do
+      Interactify::Dsl::EachChain.attach_klass(SpecSupport, [k(:A), k(:B)], plural_resource_name: :things, caller_info:)
+    end
+    let(:caller_info) { "/some/path/to/file.rb:123" }
 
     it "attaches a new class to the passed in context" do
       expect(chain.name).to match(/SpecSupport::EachThing\d+/)

--- a/spec/lib/interactify/dsl/each_chain_spec.rb
+++ b/spec/lib/interactify/dsl/each_chain_spec.rb
@@ -2,9 +2,10 @@
 
 RSpec.describe Interactify::Dsl::EachChain do
   describe ".attach_klass" do
-    it "attaches a new class to the passed in context" do
-      chain = Interactify::Dsl::EachChain.attach_klass(SpecSupport, :things, [k(:A), k(:B)])
+    let(:chain) { Interactify::Dsl::EachChain.attach_klass(SpecSupport, [k(:A), k(:B)], plural_resource_name: :things, caller_info:) }
+    let(:caller_info) { '/some/path/to/file.rb:123' }
 
+    it "attaches a new class to the passed in context" do
       expect(chain.name).to match(/SpecSupport::EachThing\d+/)
 
       result = chain.call!(things: [1, 2, 3])
@@ -15,8 +16,6 @@ RSpec.describe Interactify::Dsl::EachChain do
 
     context "when expected key is missing in context" do
       it "raises an error" do
-        chain = Interactify::Dsl::EachChain.attach_klass(SpecSupport, :things, [k(:A), k(:B)])
-
         expect { chain.call!(other_things: [1, 2, 3]) }
           .to raise_error do |error|
           expect(error).to be_a described_class::MissingIteratableValueInContext

--- a/spec/lib/interactify/dsl_spec.rb
+++ b/spec/lib/interactify/dsl_spec.rb
@@ -20,8 +20,10 @@ RSpec.describe Interactify::Dsl do
           slot,
           :condition,
           :success,
-          :failure
+          :failure,
+          caller_info: an_instance_of(String)
         )
+
       end
 
       let(:on_success1) do

--- a/spec/lib/interactify/dsl_spec.rb
+++ b/spec/lib/interactify/dsl_spec.rb
@@ -74,6 +74,18 @@ RSpec.describe Interactify::Dsl do
           expect(result.success1).to eq(false)
           expect(result.success2).to eq(false)
         end
+
+        context 'when unexpected keys' do
+          it 'raises an error' do
+            expect {
+              slot.if(
+                :condition,
+                when: [on_success1, on_success2],
+                else: [on_failure1, on_failure2],
+              )
+            }.to raise_error(described_class::IfDefinitionUnexpectedKey, 'Unexpected keys: when')
+          end
+        end
       end
     end
   end

--- a/spec/lib/interactify/dsl_spec.rb
+++ b/spec/lib/interactify/dsl_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Interactify::Dsl do
           :failure,
           caller_info: an_instance_of(String)
         )
-
       end
 
       let(:on_success1) do
@@ -77,15 +76,15 @@ RSpec.describe Interactify::Dsl do
           expect(result.success2).to eq(false)
         end
 
-        context 'when unexpected keys' do
-          it 'raises an error' do
-            expect {
+        context "when unexpected keys" do
+          it "raises an error" do
+            expect do
               slot.if(
                 :condition,
                 when: [on_success1, on_success2],
-                else: [on_failure1, on_failure2],
+                else: [on_failure1, on_failure2]
               )
-            }.to raise_error(described_class::IfDefinitionUnexpectedKey, 'Unexpected keys: when')
+            end.to raise_error(described_class::IfDefinitionUnexpectedKey, "Unexpected keys: when")
           end
         end
       end

--- a/spec/lib/interactify_spec.rb
+++ b/spec/lib/interactify_spec.rb
@@ -5,6 +5,20 @@ RSpec.describe Interactify do
     expect(Interactify::VERSION).not_to be nil
   end
 
+  describe '.trigger_definition_error' do
+    context 'with the definition error handler set' do
+      before do
+        Interactify.on_definition_error do |error|
+          "foo: #{error}"
+        end
+      end
+
+      it 'triggers the handler' do
+        expect(Interactify.trigger_definition_error('some_error')).to eq('foo: some_error')
+      end
+    end
+  end
+
   describe ".validate_app" do
     before do
       wiring = instance_double(Interactify::Wiring, validate_app: "ok")

--- a/spec/lib/interactify_spec.rb
+++ b/spec/lib/interactify_spec.rb
@@ -5,16 +5,16 @@ RSpec.describe Interactify do
     expect(Interactify::VERSION).not_to be nil
   end
 
-  describe '.trigger_definition_error' do
-    context 'with the definition error handler set' do
+  describe ".trigger_definition_error" do
+    context "with the definition error handler set" do
       before do
         Interactify.on_definition_error do |error|
           "foo: #{error}"
         end
       end
 
-      it 'triggers the handler' do
-        expect(Interactify.trigger_definition_error('some_error')).to eq('foo: some_error')
+      it "triggers the handler" do
+        expect(Interactify.trigger_definition_error("some_error")).to eq("foo: some_error")
       end
     end
   end


### PR DESCRIPTION
Adds in a few things to improve ergonomics of debugging interactor chains

- make raising definition errors optional
- add info to README on hook configuration
- raise an error when finding unexpected keys in Interactify.if clause
- propagate caller info through nested chains

## Optional definition error raising
By configuring a different mechanism for raising failures we can optionally not blow up at load time for `.organizing` failures. This would enable collating the errors in a spec to output and also enables us to add back in lambda debugging during development.


```ruby
Interactify.on_definition_error do |error|
  SomeErrorCollectionObject.append error 
end
```

Without this when you put a `byebug` in a lambda, the new `.organizing` assertions were blowing up the whole application due to not expecting an extra lambda there. I may look into ways we can skip over these scenarios, but I'm not sure if I can think of something off the top of my head.

```ruby
class Outer
  include Interactiy
  
  organize \
    Step1,
    Step2.organizing(NestedStep3,. NestedStep4)
end

class Step2
  include Interactify

  organize(NestedStep3, -> { byebug }, NestedStep4)
  #                       ^----------^ this was blowing up when loading the `Outer` class
```

## Raise an error for if clauses

```ruby
organize(
  self.if(SomeCondition, A, else: B),
  C, D, E
)
```


The error for the `if` DSL clause missing the `then:` key was obscure and blowing up inside the DSL internals. So this makes it more explicit.


### Propagate caller info
Invalid nested if/each chains resulted in a stacktrace pointing to the DSL internals which in RSpec without `--backtrace` means rather than pointing to your application code a few times so you could understand which point in the chain it was referring to, it would point at the top call site and all the rest would be DSL internals and not show in the backtrace by default. 

This now should at least let you see you're inside an `each` then an `if`, then another `each` etc. 

Combined with adding in better exceptions for invalid DSL configuration we should mostly be able to avoid looking at things at this level. I'll look into following on with better exception raising in `.each` and `.chain` too. But this should be an improvement as is.