### PR TITLE
fix wrong constant name in chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 - Add support for `Interactify.with(queue: 'within_30_seconds', retry: 3)`
+- Fix issue with anonymous classes not being able to be used in chains
 
 ## [0.5.0] - 2024-01-01
 - Add support for `SetA = Interactify { _1.a = 'a' }`, lambda and block class creation syntax

--- a/lib/interactify/dsl/unique_klass_name.rb
+++ b/lib/interactify/dsl/unique_klass_name.rb
@@ -19,7 +19,7 @@ module Interactify
       end
 
       def name_with_suffix(namespace, prefix, suffix)
-        name = [prefix.to_s, suffix.to_s].compact_blank.join("_")
+        name = [prefix.to_s, suffix.to_s].reject(&:blank?).join("_")
 
         return nil if namespace.const_defined?(name.to_sym)
 

--- a/lib/interactify/dsl/unique_klass_name.rb
+++ b/lib/interactify/dsl/unique_klass_name.rb
@@ -6,6 +6,8 @@ module Interactify
       module_function
 
       def for(namespace, prefix, camelize: true)
+        prefix = "AnonymousModule" if prefix.is_a?(Module) && prefix.anonymous?
+
         prefix = normalize_prefix(prefix:, camelize:)
         klass_name = name_with_suffix(namespace, prefix, nil)
 
@@ -17,7 +19,7 @@ module Interactify
       end
 
       def name_with_suffix(namespace, prefix, suffix)
-        name = [prefix, suffix].compact.join("_")
+        name = [prefix.to_s, suffix.to_s].compact_blank.join("_")
 
         return nil if namespace.const_defined?(name.to_sym)
 

--- a/spec/integration/all_the_things_integration_spec.rb
+++ b/spec/integration/all_the_things_integration_spec.rb
@@ -52,4 +52,26 @@ RSpec.describe "Interactify" do
       expect(result.heavily_nested_counter).to eq 256
     end
   end
+
+  context 'with anonymous classes in chains' do
+    self::SomeInteractor = Class.new do |klass|
+      include Interactify
+      anonymous_thing = Interactify { context.problem = 'problem happens here' }
+
+      A = Interactify { _1.a = 'A' }
+      B = Interactify { _1.b = 'B' }
+      C = Interactify { _1.c = 'C' }
+
+      klass::SomeChain = chain(
+        anonymous_thing,
+        A,
+        B,
+        C
+      )
+    end
+
+    it 'does not raise an error' do
+      expect { self.class::SomeInteractor::SomeChain.call! }.not_to raise_error
+    end
+  end
 end

--- a/spec/integration/all_the_things_integration_spec.rb
+++ b/spec/integration/all_the_things_integration_spec.rb
@@ -53,24 +53,24 @@ RSpec.describe "Interactify" do
     end
   end
 
-  context 'with anonymous classes in chains' do
+  context "with anonymous classes in chains" do
     self::SomeInteractor = Class.new do |klass|
       include Interactify
-      anonymous_thing = Interactify { context.problem = 'problem happens here' }
+      anonymous_thing = Interactify { context.problem = "problem happens here" }
 
-      A = Interactify { _1.a = 'A' }
-      B = Interactify { _1.b = 'B' }
-      C = Interactify { _1.c = 'C' }
+      klass::A = Interactify { _1.a = "A" }
+      klass::B = Interactify { _1.b = "B" }
+      klass::C = Interactify { _1.c = "C" }
 
       klass::SomeChain = chain(
         anonymous_thing,
-        A,
-        B,
-        C
+        klass::A,
+        klass::B,
+        klass::C
       )
     end
 
-    it 'does not raise an error' do
+    it "does not raise an error" do
       expect { self.class::SomeInteractor::SomeChain.call! }.not_to raise_error
     end
   end


### PR DESCRIPTION
Fixes #33

Use an explicit name for any anonymous modules created to avoid autogenerated invalid names like
`#<Class:0x0000000126a7af18>7545`
